### PR TITLE
Add Vercel Analytics

### DIFF
--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { Analytics } from "@vercel/analytics/react";
 import "./globals.css";
 import { Providers } from "./providers";
 
@@ -30,6 +31,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <Providers>{children}</Providers>
+        <Analytics />
       </body>
     </html>
   );

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -17,6 +17,7 @@
         "@trpc/react-query": "^11.8.0",
         "@trpc/server": "^11.8.0",
         "@types/dagre": "^0.7.53",
+        "@vercel/analytics": "^1.6.1",
         "dagre": "^0.8.5",
         "dotenv": "^17.2.3",
         "next": "16.0.10",
@@ -2966,6 +2967,44 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.6.1.tgz",
+      "integrity": "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",

--- a/site/package.json
+++ b/site/package.json
@@ -18,6 +18,7 @@
     "@trpc/react-query": "^11.8.0",
     "@trpc/server": "^11.8.0",
     "@types/dagre": "^0.7.53",
+    "@vercel/analytics": "^1.6.1",
     "dagre": "^0.8.5",
     "dotenv": "^17.2.3",
     "next": "16.0.10",


### PR DESCRIPTION
## Summary
- Install `@vercel/analytics` and add the `<Analytics />` component to the root layout
- Page views will be tracked automatically on the Vercel dashboard after deploy

## Test plan
- [ ] Verify the site builds successfully on Vercel
- [ ] Check the Vercel Analytics dashboard shows data after visiting the deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)